### PR TITLE
KAP-1888 Adding argument to REST methods

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -10,6 +10,7 @@ export interface MethodArgument extends TypeLike {}
 
 export interface RESTMethodArgument extends MethodArgument {
     transport?: string;
+    argument?: string;
 }
 
 export interface Method<T extends MethodArgument> {


### PR DESCRIPTION
Header needs to have an argument in order to make sense